### PR TITLE
Adding CacheIR instruction sequences to output of 'Details' section of analyzer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,49 +2,8 @@
 <html>
 <head>
 <meta charset="utf-8">
+<link rel="stylesheet" href="./style.css" />
 <title>CacheIR Analyzer</title>
-<style>
-
-* {
-    box-sizing: border-box;
-}
-
-html {
-    background-color: #f8f9fa;
-}
-
-body {
-    font-family: sans-serif;
-    margin: 2em;
-}
-
-
-#details > table {
-    margin-bottom: 1em;
-}
-
-#msg {
-    color: red;
-}
-
-label {
-    display: block;
-    font-size: 120%;
-    padding-bottom: 0.2em;
-}
-
-input[type=text], select {
-    width: 20em;
-}
-
-form div {
-    padding-bottom: 0.4em;
-}
-
-#clear {
-    color: inherit;
-}
-</style>
 </head>
 <body>
 <h1>CacheIR Analyzer</h1>

--- a/index.js
+++ b/index.js
@@ -42,15 +42,12 @@ function generateCacheIRInstructionTable(cacheIRArray) {
     // property and value to  the string of HTML that will be injected into the
     // page.
     elt.args.forEach((arg) => {
-        if( arg.hasOwnProperty('Id')
-            || arg.hasOwnProperty('Field') ) {
-
+        if (arg.hasOwnProperty('Id') || arg.hasOwnProperty('Field')) {
           cacheIRstr += '<td class="arg-td">'
             +Object.entries(arg).join('').replace(',', '') + '</td>';
-        }
-        else {
+        } else {
           let key = Object.getOwnPropertyNames(arg);
-          if( key.length > 0 ){
+          if (key.length > 0) {
             key = key[0];
 
             // If the argument property is "Word", convert the integer value
@@ -63,8 +60,10 @@ function generateCacheIRInstructionTable(cacheIRArray) {
           }
         }
     });
+
     cacheIRstr += "</tr>"
   });
+
   cacheIRstr += "</tbody>"
   cacheIRstr += "</table>"
   return cacheIRstr;

--- a/index.js
+++ b/index.js
@@ -22,9 +22,58 @@ const MODES = [
     "Generic"
 ];
 
+// Helper function to generate the HTML string of a table element containing
+// information read from the cacheIR instruction sequence log JSON.
+function generateCacheIRInstructionTable(cacheIRArray) {
+
+  let cacheIRstr = "";
+  cacheIRstr += '<table class="cacheir-inst-seq-table">'
+  cacheIRstr += '<tbody class="cacheir-inst-seq-tbody">'
+
+  // The JSON of the cacheIR instruction sequence logs contains arrays of
+  // objects. Below gets each element of the array, appends the operation value
+  // to the string of HTML.
+  cacheIRArray.forEach((elt) => {
+    cacheIRstr += '<tr class="cacheir-inst-seq-tr">'
+    cacheIRstr += '<td class="op-td">'+elt.op + '</td>';
+
+    // The value of the args property of the cacheIR instruction sequence JSON
+    // is also an array. Here, for each element of the array, we append the
+    // property and value to  the string of HTML that will be injected into the
+    // page.
+    elt.args.forEach((arg) => {
+        if( arg.hasOwnProperty('Id')
+            || arg.hasOwnProperty('Field') ) {
+
+          cacheIRstr += '<td class="arg-td">'
+            +Object.entries(arg).join('').replace(',', '') + '</td>';
+        }
+        else {
+          let key = Object.getOwnPropertyNames(arg);
+          if( key.length > 0 ){
+            key = key[0];
+
+            // If the argument property is "Word", convert the integer value
+            // to hex, otherwise just print the integer value.
+            cacheIRstr += '<td class="arg-td">'
+                +key
+                +(( key.toLowerCase() === "word" ) ?
+                  '(0x'+parseInt(arg[key], 10).toString(16)+')'+'</td>'
+                : '('+parseInt(arg[key], 10)+')'+'</td>');
+          }
+        }
+    });
+    cacheIRstr += "</tr>"
+  });
+  cacheIRstr += "</tbody>"
+  cacheIRstr += "</table>"
+  return cacheIRstr;
+}
+
 function showObjects(objects) {
     function showObject(obj) {
         let table = document.createElement("table");
+
         table.innerHTML = `
         <tr>
             <td>Type</td><td>${obj.name} <b>${obj.attached ? obj.attached : ""}</b><td>
@@ -40,6 +89,10 @@ function showObjects(objects) {
         </tr>
         <tr>
             <td>PC</td><td>${obj.pc}</td>
+        </tr>
+        <tr>
+            <td class="cacheir-inst-td">Instructions</td><td>${obj.cacheIR ?
+              generateCacheIRInstructionTable(obj.cacheIR) : ""}</td>
         </tr>
         `;
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+* {
+    box-sizing: border-box;
+}
+
+html {
+    background-color: #f8f9fa;
+}
+
+body {
+    font-family: sans-serif;
+    margin: 2em;
+}
+
+
+#details > table {
+    margin-bottom: 1em;
+}
+
+#msg {
+    color: red;
+}
+
+label {
+    display: block;
+    font-size: 120%;
+    padding-bottom: 0.2em;
+}
+
+input[type=text], select {
+    width: 20em;
+}
+
+form div {
+    padding-bottom: 0.4em;
+}
+
+#clear {
+    color: inherit;
+}
+
+.cacheir-inst-td {
+  vertical-align: top;
+}
+
+.op-td, .arg-td {
+  padding-right: 0.5em;
+}
+
+.cacheir-inst-seq-table {
+  padding-top: 1.0em;
+  padding-bottom: 1.0em;
+}
+
+.cacheir-inst-seq-table .op-td, .cacheir-inst-seq-table .arg-td {
+  text-align: left;
+}


### PR DESCRIPTION
This PR is for [Bug 1548273 - Update CacheIR analyzer to display bytecode](https://bugzilla.mozilla.org/show_bug.cgi?id=1548273).

I added the CacheIR instruction sequence output to the information that is displayed in the 'Details' section of the analyzer. I added a stylesheet for styling of the tables in which that information is displayed.
